### PR TITLE
Fix arrow key scrolling and add overflow handling

### DIFF
--- a/components/GameEngine.js
+++ b/components/GameEngine.js
@@ -169,17 +169,21 @@ export default function GameEngine() {
     backgroundRef.current = new Image();
     backgroundRef.current.src = "/backgrounds/stage.png";
 
+    const preventKeys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"];
+
     function handleKeyDown(e) {
+      if (preventKeys.includes(e.code)) e.preventDefault();
       keys.current[e.code] = true;
       inputBuffer.current.push({ code: e.code, time: Date.now() });
       // keep last 3 inputs
       if (inputBuffer.current.length > 3) inputBuffer.current.shift();
     }
     function handleKeyUp(e) {
+      if (preventKeys.includes(e.code)) e.preventDefault();
       keys.current[e.code] = false;
     }
-    window.addEventListener("keydown", handleKeyDown);
-    window.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("keydown", handleKeyDown, { passive: false });
+    window.addEventListener("keyup", handleKeyUp, { passive: false });
     let aiInterval;
 
     function chooseNpcAction() {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  /* Prevent the window from scrolling when the game is played */
+  margin: 0;
+  overflow: hidden;
+}
+
 .canvas-container {
   @apply flex justify-center items-center mt-4;
 }


### PR DESCRIPTION
## Summary
- prevent the browser from scrolling when using arrow keys
- disable body scrollbars so the background doesn't move

## Testing
- `npm run build` *(fails: `next` not found)*